### PR TITLE
bump springfeatures to stable tag (1.5)

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -12,7 +12,7 @@ local modinfo = {
 	modtype			= 0,
 	depend = {
         "Spring Cursors",
-        "Spring Features v1.1",
+        "Spring Features v1.5",
 
         -- mods here :
 		-- enter your mod here!


### PR DESCRIPTION
just to ease installation, so folks can just grab spring-features:stable. I'm not even sure where to get 1.1 from these days.